### PR TITLE
align schema naming to staging, int and marts convention

### DIFF
--- a/fdadata/transformations/dbt_project.yml
+++ b/fdadata/transformations/dbt_project.yml
@@ -19,14 +19,14 @@ clean-targets:         # directories to be removed by `dbt clean`
 
 models:
   transformations:
-    bronze:
-      +schema: bronze
+    staging:
+      +schema: staging
+      +materialized: view
+    intermediate:
+      +schema: intermediate
       +materialized: table
-    silver:
-      +schema: silver
-      +materialized: table
-    gold:
-      +schema: gold
+    marts:
+      +schema: marts
       +materialized: table
 
 data_tests:

--- a/fdadata/transformations/models/intermediate/int_drug_active_ingredients_unnested.sql
+++ b/fdadata/transformations/models/intermediate/int_drug_active_ingredients_unnested.sql
@@ -1,7 +1,9 @@
 with active_ingreditens as (
     select
         product_id,
-        (jsonb_array_elements(active_ingredients) ->> 'name'),
+        (
+            jsonb_array_elements(active_ingredients) ->> 'name'
+        ) as ingredient_name,
         (jsonb_array_elements(active_ingredients) ->> 'strength') as strength
     from {{ ref("stg_fda__ndc") }}
 )
@@ -9,7 +11,7 @@ with active_ingreditens as (
 colese_missing_strength as (
     select
         product_id,
-        name,
+        ingredient_name,
         coalesce(strength, '1/1') as strength
     from active_ingreditens
 )

--- a/fdadata/transformations/models/intermediate/int_drug_active_ingredients_unnested.sql.yml
+++ b/fdadata/transformations/models/intermediate/int_drug_active_ingredients_unnested.sql.yml
@@ -12,7 +12,7 @@ models:
         description: "ProductID is a concatenation of the NDC product code and SPL documentID."
         tests:
           - not_null
-      - name: name
+      - name: ingredient_name
         data_type: text
         description: "Name of the active ingreedinet"
         tests:

--- a/fdadata/transformations/models/marts/labelers.sql
+++ b/fdadata/transformations/models/marts/labelers.sql
@@ -2,7 +2,7 @@ select
     dm.labeler_name,
     count(distinct dm.product_id) as total_drugs,
     count(distinct gdi.product_id) as generic_drugs_count,
-    count(distinct dai.name) as distinct_active_ingredients
+    count(distinct dai.ingredient_name) as distinct_active_ingredients
 from {{ ref('int_ndc_labelers_deduplicated') }} as dm
 left join {{ ref('int_generic_drug_identificated') }} as gdi
     on dm.product_id = gdi.product_id


### PR DESCRIPTION
- Fixed schema names in the dbt_project to be aligned with the new dbt project structure.
- changed column name in fdadata/transformations/models/intermediate/int_drug_active_ingredients_unnested.sql to `ingredient_name` for better clarity. 